### PR TITLE
Update on ansible.j2 template file. Changed default of item.users to ALL

### DIFF
--- a/templates/etc/sudoers.d/ansible.j2
+++ b/templates/etc/sudoers.d/ansible.j2
@@ -5,6 +5,6 @@ Defaults{{ ":" ~ item.name if item.name is defined else "" }} {{ item.defaults }
 {% endfor %}
 
 {% for item in sudo_users %}
-{{ item.name }} {{ item.hosts | default('ALL') }}={{ "(" ~ item.users ~ ")" if item.users is defined else "" }} {{ "NOPASSWD:" if item.nopasswd | default(false) else "" }} {{ item.commands | default('ALL') }}
+{{ item.name }} {{ item.hosts | default('ALL') }}={{ "(" ~ item.users | default('ALL') ~ ")" }} {{ "NOPASSWD:" if item.nopasswd | default(false) else "" }} {{ item.commands | default('ALL') }}
 {% endfor %}
 


### PR DESCRIPTION
Hi!
Thanks for creating this role. I noticed that when omitting the items.users variable the default action is to insert "" . In the documentation found in the /etc/sudoers configuration file it seems that (ALL) is somewhat the default. So i changed the template to reflect that.

Kind regards,
Martijn
